### PR TITLE
Fix /tests/:test_uuid route

### DIFF
--- a/tng-router/config/vnv_routes.yml
+++ b/tng-router/config/vnv_routes.yml
@@ -47,5 +47,5 @@ paths:
     site: http://tng-gtk-common:5000/functions
     verbs: [ get, options ]
   /api/v3/tests(/?|/*):
-    site: http://tng-gtk-vnv:5000/
+    site: http://tng-gtk-vnv:5000
     verbs: [ get, options ]


### PR DESCRIPTION
We were using a mapping ending in '/', which caused a wrong '//' being
received by tng-gtk-vnv