### PR TITLE
Add roles endpoint

### DIFF
--- a/tng-router/config.ru
+++ b/tng-router/config.ru
@@ -71,13 +71,13 @@ end
 
 Dir.glob(File.join(__dir__, 'lib', '**', '*.rb')).each { |file| require file } if Dir.exist?('lib')
 
+use Throttle, profiles: Dispatcher.configuration.throttling unless ENV['NO_THROTTLE']
 use Instrumentation unless ENV['NO_KPIS']
 use ReadinessLiveliness
+use Roles, roles: routes_to_roles(Dispatcher.configuration.paths)
 use Authentication unless ENV['NO_AUTH']
-use Throttle, profiles: Dispatcher.configuration.throttling unless ENV['NO_THROTTLE']
 use ConfigFinder, base_path: Dispatcher.configuration.base_path, paths: Dispatcher.configuration.paths
 use Authorization, paths: Dispatcher.configuration.paths unless ENV['NO_AUTH']
-use Roles, roles: routes_to_roles Dispatcher.configuration.paths
 use Getter
 use EmbodiedMethod
 use OtherMethods

--- a/tng-router/lib/middlewares/roles.rb
+++ b/tng-router/lib/middlewares/roles.rb
@@ -1,0 +1,58 @@
+## Copyright (c) 2015 SONATA-NFV, 2017 5GTANGO [, ANY ADDITIONAL AFFILIATION]
+## ALL RIGHTS RESERVED.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+## Neither the name of the SONATA-NFV, 5GTANGO [, ANY ADDITIONAL AFFILIATION]
+## nor the names of its contributors may be used to endorse or promote
+## products derived from this software without specific prior written
+## permission.
+##
+## This work has been performed in the framework of the SONATA project,
+## funded by the European Commission under Grant number 671517 through
+## the Horizon 2020 and 5G-PPP programmes. The authors would like to
+## acknowledge the contributions of their colleagues of the SONATA
+## partner consortium (www.sonata-nfv.eu).
+##
+## This work has been performed in the framework of the 5GTANGO project,
+## funded by the European Commission under Grant number 761493 through
+## the Horizon 2020 and 5G-PPP programmes. The authors would like to
+## acknowledge the contributions of their colleagues of the 5GTANGO
+## partner consortium (www.5gtango.eu).
+# frozen_string_literal: true
+# encoding: utf-8
+require 'rack'
+require 'tng/gtk/utils/logger'
+require_relative '../utils'
+
+class Roles
+  LOGGER=Tng::Gtk::Utils::Logger
+  LOGGED_COMPONENT=self.name
+  
+  def initialize(app, options={})
+    @app, @roles = app, options[:roles]
+  end
+
+  def call(env)
+    msg = '#'+__method__.to_s
+    return [200, {'Content-Type'=>'application/json'}, [{roles: @roles}.to_json]] if is_roles_request?(env)
+    @app.call(env)
+  end
+  
+  private
+  def is_roles_request?(env)
+    env['REQUEST_METHOD'] == 'GET' &&
+    env['REQUEST_PATH'].split('/')[-1] == 'roles'
+  end
+end
+


### PR DESCRIPTION
Routes are configured in `./config/*_routes.yml` with data about which
roles can access which endpoint doing what (HTTP verb). This middleware
simply 'inverts' that, providing a list of roles instead.