### PR TITLE
added routes for SDK backend

### DIFF
--- a/tng-sec-gtw/default-no-ssl.conf
+++ b/tng-sec-gtw/default-no-ssl.conf
@@ -31,4 +31,40 @@ server {
                 proxy_pass_request_body on;
                 proxy_hide_header Public-key-pins;
         }
+		
+		location /api/v1/projects {
+				resolver 127.0.0.11;
+				set $projects http://tng-sdk-portal-backend{DOMAIN}:5098$uri$is_args$query_string;
+				proxy_pass $projects;
+				proxy_set_header Host $host;
+				proxy_pass_request_headers on;
+				proxy_pass_request_body on;
+				proxy_hide_header Public-key-pins;
+		}
+
+		location /tng-lab/ {
+				resolver 127.0.0.11;
+				set $lab http://tng-sdk-portal-backend{DOMAIN}:8888$uri$is_args$query_string;
+				proxy_pass $lab;
+				proxy_set_header Host $host;
+				proxy_pass_request_headers on;
+				proxy_pass_request_body on;
+				proxy_hide_header Public-key-pins;
+		}
+
+		location ~* /(api/kernels/[^/]+/(channels|iopub|shell|stdin)|terminals/websocket)/? {
+				resolver 127.0.0.11;
+				set $sockets http://tng-sdk-portal-backend{DOMAIN}:8888$uri$is_args$query_string;
+				proxy_pass $sockets;
+				proxy_set_header Host $host;
+				proxy_pass_request_headers on;
+				proxy_pass_request_body on;
+				proxy_hide_header Public-key-pins;
+
+				# WebSocket support
+				proxy_http_version 1.1;
+				proxy_set_header      Upgrade "websocket";
+				proxy_set_header      Connection "Upgrade";
+				proxy_read_timeout    86400;
+		}
 }

--- a/tng-sec-gtw/default-ssl.conf
+++ b/tng-sec-gtw/default-ssl.conf
@@ -41,8 +41,8 @@ server {
 	
 	location /api/v1/projects {
                 resolver 127.0.0.11;
-                set $api http://tng-sdk-portal-backend{DOMAIN}:5098$uri$is_args$query_string;
-                proxy_pass $api;
+                set $projects http://tng-sdk-portal-backend{DOMAIN}:5098$uri$is_args$query_string;
+                proxy_pass $projects;
                 proxy_set_header Host $host;
                 proxy_pass_request_headers on;
                 proxy_pass_request_body on;
@@ -51,8 +51,8 @@ server {
 	
 	location /lab/ {
                 resolver 127.0.0.11;
-                set $api http://tng-sdk-portal-backend{DOMAIN}:8888$uri$is_args$query_string;
-                proxy_pass $api;
+                set $lab http://tng-sdk-portal-backend{DOMAIN}:8888$uri$is_args$query_string;
+                proxy_pass $lab;
                 proxy_set_header Host $host;
                 proxy_pass_request_headers on;
                 proxy_pass_request_body on;

--- a/tng-sec-gtw/default-ssl.conf
+++ b/tng-sec-gtw/default-ssl.conf
@@ -38,4 +38,24 @@ server {
                 proxy_pass_request_body on;
                 proxy_hide_header Public-key-pins;
         }
+	
+	location /api/v1/projects {
+                resolver 127.0.0.11;
+                set $api http://tng-sdk-portal-backend{DOMAIN}:5098$uri$is_args$query_string;
+                proxy_pass $api;
+                proxy_set_header Host $host;
+                proxy_pass_request_headers on;
+                proxy_pass_request_body on;
+                proxy_hide_header Public-key-pins;
+        }
+	
+	location /lab/ {
+                resolver 127.0.0.11;
+                set $api http://tng-sdk-portal-backend{DOMAIN}:8888$uri$is_args$query_string;
+                proxy_pass $api;
+                proxy_set_header Host $host;
+                proxy_pass_request_headers on;
+                proxy_pass_request_body on;
+                proxy_hide_header Public-key-pins;
+        }
 }

--- a/tng-sec-gtw/default-ssl.conf
+++ b/tng-sec-gtw/default-ssl.conf
@@ -39,23 +39,39 @@ server {
                 proxy_hide_header Public-key-pins;
         }
 	
-	location /api/v1/projects {
-                resolver 127.0.0.11;
-                set $projects http://tng-sdk-portal-backend{DOMAIN}:5098$uri$is_args$query_string;
-                proxy_pass $projects;
-                proxy_set_header Host $host;
-                proxy_pass_request_headers on;
-                proxy_pass_request_body on;
-                proxy_hide_header Public-key-pins;
-        }
-	
-	location /lab/ {
-                resolver 127.0.0.11;
-                set $lab http://tng-sdk-portal-backend{DOMAIN}:8888$uri$is_args$query_string;
-                proxy_pass $lab;
-                proxy_set_header Host $host;
-                proxy_pass_request_headers on;
-                proxy_pass_request_body on;
-                proxy_hide_header Public-key-pins;
-        }
+		location /api/v1/projects {
+				resolver 127.0.0.11;
+				set $projects http://tng-sdk-portal-backend{DOMAIN}:5098$uri$is_args$query_string;
+				proxy_pass $projects;
+				proxy_set_header Host $host;
+				proxy_pass_request_headers on;
+				proxy_pass_request_body on;
+				proxy_hide_header Public-key-pins;
+		}
+
+		location /tng-lab/ {
+				resolver 127.0.0.11;
+				set $lab http://tng-sdk-portal-backend{DOMAIN}:8888$uri$is_args$query_string;
+				proxy_pass $lab;
+				proxy_set_header Host $host;
+				proxy_pass_request_headers on;
+				proxy_pass_request_body on;
+				proxy_hide_header Public-key-pins;
+		}
+
+		location ~* /(api/kernels/[^/]+/(channels|iopub|shell|stdin)|terminals/websocket)/? {
+				resolver 127.0.0.11;
+				set $sockets http://tng-sdk-portal-backend{DOMAIN}:8888$uri$is_args$query_string;
+				proxy_pass $sockets;
+				proxy_set_header Host $host;
+				proxy_pass_request_headers on;
+				proxy_pass_request_body on;
+				proxy_hide_header Public-key-pins;
+
+				# WebSocket support
+				proxy_http_version 1.1;
+				proxy_set_header      Upgrade "websocket";
+				proxy_set_header      Connection "Upgrade";
+				proxy_read_timeout    86400;
+		}
 }


### PR DESCRIPTION
* not sure about port of jupyter lab
* not sure about the address `http://tng-sdk-portal-backend`

@felipevicens 