### PR TITLE
Include delete method to analytic engine results

### DIFF
--- a/tng-router/config/vnv_routes.yml
+++ b/tng-router/config/vnv_routes.yml
@@ -168,8 +168,8 @@ paths:
     site: http://tng-analytics-results:80
     permissions:
     - role: admin
-      verbs: 'options,get'
+      verbs: 'options,get,delete'
     - role: developer
-      verbs: 'get,options'
+      verbs: 'get,options,delete'
     - role: customer
       verbs: 'get'


### PR DESCRIPTION
Include delete method to analytic engine results endpoint so that admin and developers can remove the results.

Coming from https://github.com/sonata-nfv/tng-portal/issues/456

cc @jbonnet 